### PR TITLE
APEX-81 - Fix netlet snapshot dependency. Enforce no dependencies on snapshot versions in release builds.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netlet</artifactId>
-      <version>1.2.0-SNAPSHOT</version>
+      <version>1.2.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.0.1</version>
+        <version>1.4.1</version>
         <executions>
           <execution>
             <id>enforce-tools</id>
@@ -117,6 +117,10 @@
                 <requireMavenVersion>
                   <version>[3.0.2,)</version>
                 </requireMavenVersion>
+                <requireReleaseDeps>
+                  <message>Snapshots are not allowed</message>
+                  <onlyWhenRelease>true</onlyWhenRelease>
+                </requireReleaseDeps>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
@243826 Please merge after netlet 1.2 is released to maven central repository.