### PR TITLE
Fix APEX-141: Fix ClientHandler Not Found exception in Hadoop 2.2

### DIFF
--- a/engine/src/main/java/com/datatorrent/stram/StramClient.java
+++ b/engine/src/main/java/com/datatorrent/stram/StramClient.java
@@ -121,6 +121,7 @@ public class StramClient
       org.mozilla.javascript.Scriptable.class,
       // The jersey client inclusion is only for Hadoop-2.2 and should be removed when we upgrade our Hadoop
       // dependency version since Hadoop-2.3 onwards has jersey client bundled
+      com.sun.jersey.api.client.ClientHandler.class,
       com.sun.jersey.client.apache4.ApacheHttpClient4Handler.class
   };
 


### PR DESCRIPTION
Add class com.sun.jersey.api.client.ClientHandler.class into DATATORRENT_CLASSES